### PR TITLE
プロフィール画像アップロード機能とゲスト表示名制限の追加

### DIFF
--- a/lib/screens/auth_screen.dart
+++ b/lib/screens/auth_screen.dart
@@ -180,6 +180,7 @@ class _AuthScreenState extends State<AuthScreen> {
       'email': user.email,
       'emailLower': user.email?.toLowerCase(),
       'displayName': user.displayName,
+      'photoUrl': user.photoURL,
       'isGuest': user.isAnonymous,
       'updatedAt': FieldValue.serverTimestamp(),
     };


### PR DESCRIPTION
## Summary
- プロフィール画面で画像を選択してFirebase Storageにアップロードし、FirestoreとFirebaseAuthの情報を更新する処理を追加
- ゲストユーザーの表示名変更をサーバー・UIの両方で禁止し、案内テキストを表示
- 認証・ゲスト連携時にプロフィール画像URLをuserProfilesに保存するよう更新

## Testing
- Flutter CLI がコンテナに存在しないためテストを実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_68d0e24d9a5083319276488455b0039e