### PR TITLE
Improve alpha warning UX and search responsiveness

### DIFF
--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import '../models/memo.dart';
 import '../utils/database_helper.dart';
@@ -14,28 +16,34 @@ class _SearchScreenState extends State<SearchScreen> {
   final TextEditingController _searchController = TextEditingController();
   List<Memo> _searchResults = [];
   bool _isSearching = false;
+  bool _hasSearched = false;
+  Timer? _debounce;
 
   @override
   void dispose() {
+    _debounce?.cancel();
     _searchController.dispose();
     super.dispose();
   }
 
   Future<void> _performSearch(String query) async {
-    if (query.trim().isEmpty) {
+    final trimmedQuery = query.trim();
+    if (trimmedQuery.isEmpty) {
       setState(() {
         _searchResults = [];
         _isSearching = false;
+        _hasSearched = false;
       });
       return;
     }
 
     setState(() {
       _isSearching = true;
+      _hasSearched = true;
     });
 
     try {
-      final results = await DatabaseHelper.instance.searchMemos(query);
+      final results = await DatabaseHelper.instance.searchMemos(trimmedQuery);
       setState(() {
         _searchResults = results;
         _isSearching = false;
@@ -50,6 +58,13 @@ class _SearchScreenState extends State<SearchScreen> {
     }
   }
 
+  void _onSearchChanged(String value) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 400), () {
+      _performSearch(value);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -62,96 +77,125 @@ class _SearchScreenState extends State<SearchScreen> {
           children: [
             TextField(
               controller: _searchController,
-              decoration: const InputDecoration(
+              decoration: InputDecoration(
                 hintText: 'ピンの名前または地図の名前で検索',
-                prefixIcon: Icon(Icons.search),
-                border: OutlineInputBorder(),
+                prefixIcon: const Icon(Icons.search),
+                border: const OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.arrow_forward),
+                  tooltip: '検索',
+                  onPressed: () => _performSearch(_searchController.text),
+                ),
               ),
-              onChanged: (value) {
-                _performSearch(value);
-              },
+              textInputAction: TextInputAction.search,
+              onChanged: _onSearchChanged,
+              onSubmitted: _performSearch,
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton.icon(
+                onPressed: () => _performSearch(_searchController.text),
+                icon: const Icon(Icons.manage_search),
+                label: const Text('検索する'),
+              ),
             ),
             const SizedBox(height: 16),
-            if (_isSearching)
-              const Center(
-                child: CircularProgressIndicator(),
-              )
-            else if (_searchResults.isEmpty &&
-                _searchController.text.isNotEmpty)
-              const Expanded(
-                child: Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(Icons.search_off, size: 64, color: Colors.grey),
-                      SizedBox(height: 16),
-                      Text('検索結果が見つかりませんでした',
-                          style: TextStyle(color: Colors.grey)),
-                    ],
+            Expanded(
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: _buildSearchBody(),
                   ),
-                ),
-              )
-            else if (_searchResults.isEmpty)
-              const Expanded(
-                child: Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(Icons.search, size: 64, color: Colors.grey),
-                      SizedBox(height: 16),
-                      Text('検索キーワードを入力してください',
-                          style: TextStyle(color: Colors.grey)),
-                    ],
-                  ),
-                ),
-              )
-            else
-              Expanded(
-                child: ListView.builder(
-                  itemCount: _searchResults.length,
-                  itemBuilder: (context, index) {
-                    final memo = _searchResults[index];
-                    return Card(
-                      margin: const EdgeInsets.only(bottom: 8),
-                      child: ListTile(
-                        title: Text(memo.title),
-                        subtitle: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            if (memo.mapTitle != null)
-                              Text(
-                                '地図: ${memo.mapTitle}',
-                                style: const TextStyle(
-                                  color: Colors.blue,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            if (memo.content.isNotEmpty)
-                              Text(
-                                memo.content,
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                          ],
+                  if (_isSearching)
+                    const Positioned.fill(
+                      child: IgnorePointer(
+                        child: Center(
+                          child: CircularProgressIndicator(),
                         ),
-                        trailing: const Icon(Icons.arrow_forward_ios),
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) =>
-                                  MemoDetailScreen(memo: memo),
-                            ),
-                          );
-                        },
                       ),
-                    );
-                  },
-                ),
+                    ),
+                ],
               ),
+            ),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildSearchBody() {
+    if (!_hasSearched && _searchController.text.isEmpty) {
+      return const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.search, size: 64, color: Colors.grey),
+            SizedBox(height: 16),
+            Text('検索キーワードを入力してください',
+                style: TextStyle(color: Colors.grey)),
+          ],
+        ),
+      );
+    }
+
+    if (_hasSearched && _searchResults.isEmpty && !_isSearching) {
+      return const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.search_off, size: 64, color: Colors.grey),
+            SizedBox(height: 16),
+            Text('検索結果が見つかりませんでした',
+                style: TextStyle(color: Colors.grey)),
+          ],
+        ),
+      );
+    }
+
+    if (_searchResults.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return ListView.builder(
+      itemCount: _searchResults.length,
+      itemBuilder: (context, index) {
+        final memo = _searchResults[index];
+        return Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          child: ListTile(
+            title: Text(memo.title),
+            subtitle: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (memo.mapTitle != null)
+                  Text(
+                    '地図: ${memo.mapTitle}',
+                    style: const TextStyle(
+                      color: Colors.blue,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                if (memo.content.isNotEmpty)
+                  Text(
+                    memo.content,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+              ],
+            ),
+            trailing: const Icon(Icons.arrow_forward_ios),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => MemoDetailScreen(memo: memo),
+                ),
+              );
+            },
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Persist the alpha warning acknowledgement, add a settings toggle to re-enable it, and adjust bottom navigation text sizing
- Make the online map picker dialog responsive on small screens and remove the redundant add-map action from the home app bar
- Debounce memo search, add an explicit search trigger, and keep results visible while a new query is loading

## Testing
- Not run (Flutter tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e346ed2c088331a85633b9da4cce8d