### PR TITLE
Fix method scope for location retrieval handlers

### DIFF
--- a/lib/screens/add_memo_screen.dart
+++ b/lib/screens/add_memo_screen.dart
@@ -224,8 +224,9 @@ class _AddMemoScreenState extends State<AddMemoScreen> {
       );
     } finally {
       setState(() {
-      _isLocationLoading = false;
-    });
+        _isLocationLoading = false;
+      });
+    }
   }
 
   Future<void> _getCurrentLocation() async {
@@ -314,7 +315,6 @@ class _AddMemoScreenState extends State<AddMemoScreen> {
         });
       }
     }
-  }
   }
 
   Future<void> _selectDateTime() async {

--- a/lib/screens/memo_detail_screen.dart
+++ b/lib/screens/memo_detail_screen.dart
@@ -157,8 +157,9 @@ class _MemoDetailScreenState extends State<MemoDetailScreen> {
       );
     } finally {
       setState(() {
-      _isLocationLoading = false;
-    });
+        _isLocationLoading = false;
+      });
+    }
   }
 
   Future<void> _getCurrentLocation() async {
@@ -247,7 +248,6 @@ class _MemoDetailScreenState extends State<MemoDetailScreen> {
         });
       }
     }
-  }
   }
 
   // ピン番号編集ダイアログを表示


### PR DESCRIPTION
## Summary
- close the `_selectLocation` method before declaring `_getCurrentLocation` in AddMemoScreen
- apply the same fix to MemoDetailScreen so both handlers remain class members
- keep the loading state reset inside the finally block while restoring the surrounding brace structure
- remove stray closing braces that prematurely ended each state class so `_getCurrentLocation` stays accessible

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e35563fb9883319adc3c1b0eef28a9