### PR TITLE
Fix async button handlers for location actions

### DIFF
--- a/lib/screens/add_memo_screen.dart
+++ b/lib/screens/add_memo_screen.dart
@@ -2157,8 +2157,11 @@ class _AddMemoScreenState extends State<AddMemoScreen> {
                           runSpacing: 8,
                           children: [
                             ElevatedButton.icon(
-                              onPressed:
-                                  _isLocationLoading ? null : _selectLocation,
+                              onPressed: _isLocationLoading
+                                  ? null
+                                  : () async {
+                                      await _selectLocation();
+                                    },
                               icon: _isLocationLoading
                                   ? const SizedBox(
                                       width: 16,
@@ -2172,7 +2175,9 @@ class _AddMemoScreenState extends State<AddMemoScreen> {
                             OutlinedButton.icon(
                               onPressed: _isFetchingCurrentLocation
                                   ? null
-                                  : _getCurrentLocation,
+                                  : () async {
+                                      await _getCurrentLocation();
+                                    },
                               icon: _isFetchingCurrentLocation
                                   ? const SizedBox(
                                       width: 16,

--- a/lib/screens/memo_detail_screen.dart
+++ b/lib/screens/memo_detail_screen.dart
@@ -923,8 +923,11 @@ class _MemoDetailScreenState extends State<MemoDetailScreen> {
                         runSpacing: 8,
                         children: [
                           ElevatedButton.icon(
-                            onPressed:
-                                _isLocationLoading ? null : _selectLocation,
+                            onPressed: _isLocationLoading
+                                ? null
+                                : () async {
+                                    await _selectLocation();
+                                  },
                             icon: _isLocationLoading
                                 ? const SizedBox(
                                     width: 16,
@@ -942,7 +945,9 @@ class _MemoDetailScreenState extends State<MemoDetailScreen> {
                           OutlinedButton.icon(
                             onPressed: _isFetchingCurrentLocation
                                 ? null
-                                : _getCurrentLocation,
+                                : () async {
+                                    await _getCurrentLocation();
+                                  },
                             icon: _isFetchingCurrentLocation
                                 ? const SizedBox(
                                     width: 16,


### PR DESCRIPTION
## Summary
- wrap the location selection and current location retrieval handlers in async closures for both memo detail and add memo screens
- ensure the buttons satisfy the expected void callbacks while still awaiting the underlying asynchronous operations

## Testing
- not run (environment limitation)

------
https://chatgpt.com/codex/tasks/task_e_68e35bb3c5b08331865997524cbed9cd